### PR TITLE
Refactor date util

### DIFF
--- a/lib/dateUtils.js
+++ b/lib/dateUtils.js
@@ -1,0 +1,25 @@
+export function getCurrentDate() {
+  const currentDate = new Date();
+  const year = currentDate.getFullYear();
+  const month = currentDate.getMonth() + 1;
+  const day = currentDate.getDate();
+  const hour = currentDate.getHours();
+  const min = currentDate.getMinutes();
+  const sec = currentDate.getSeconds();
+  const msec = currentDate.getMilliseconds();
+  return (
+    year +
+    '-' +
+    String(month).padStart(2, '0') +
+    '-' +
+    String(day).padStart(2, '0') +
+    '-' +
+    String(hour).padStart(2, '0') +
+    '-' +
+    String(min).padStart(2, '0') +
+    '-' +
+    String(sec).padStart(2, '0') +
+    '-' +
+    String(msec).padStart(3, '0')
+  );
+}

--- a/pages/api/log.js
+++ b/pages/api/log.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+import { getCurrentDate } from '../../lib/dateUtils';
 
 export default async function handler(req, res) {
   // postじゃないならエラー
@@ -37,30 +38,3 @@ export default async function handler(req, res) {
   });
 }
 
-function getCurrentDate() {
-  const currentDate = new Date();
-  // 年
-  const year = currentDate.getFullYear();
-  // 月
-  const month = currentDate.getMonth() + 1;
-  // 日
-  const day = currentDate.getDate();
-  // 時間
-  const hour = currentDate.getHours();
-  // 分
-  const min = currentDate.getMinutes();
-  // 秒
-  const sec = currentDate.getSeconds();
-  // ミリ秒
-  const msec = currentDate.getMilliseconds();
-
-  const date =
-    year + '-' +
-    String(month).padStart(2, "0") + '-' +
-    String(day).padStart(2, "0") + '-' +
-    String(hour).padStart(2, "0") + '-' +
-    String(min).padStart(2, "0") + '-' +
-    String(sec).padStart(2, "0") + '-' +
-    String(msec).padStart(3, "0");
-  return date;
-}

--- a/pages/api/tts.js
+++ b/pages/api/tts.js
@@ -4,6 +4,8 @@ const {Storage} = require('@google-cloud/storage');
 const storage = new Storage();
 const bucketName = 'digital-human-client';
 
+import { getCurrentDate } from '../../lib/dateUtils';
+
 // Import other required libraries
 const fs = require('fs');
 const util = require('util');
@@ -80,33 +82,6 @@ async function uploadFile(filePath) {
   await storage.bucket(bucketName).upload(filePath, options);
 }
 
-function getCurrentDate() {
-  const currentDate = new Date();
-  // 年
-  const year = currentDate.getFullYear();
-  // 月
-  const month = currentDate.getMonth() + 1;
-  // 日
-  const day = currentDate.getDate();
-  // 時間
-  const hour = currentDate.getHours();
-  // 分
-  const min = currentDate.getMinutes();
-  // 秒
-  const sec = currentDate.getSeconds();
-  // ミリ秒
-  const msec = currentDate.getMilliseconds();
-
-  const date =
-    year + '-' +
-    String(month).padStart(2, "0") + '-' +
-    String(day).padStart(2, "0") + '-' +
-    String(hour).padStart(2, "0") + '-' +
-    String(min).padStart(2, "0") + '-' +
-    String(sec).padStart(2, "0") + '-' +
-    String(msec).padStart(3, "0");
-  return date;
-}
 
 function getByteLength(str) {
   return encodeURI(str).split(/%..|./).length - 1;


### PR DESCRIPTION
## Summary
- centralize date generation helper in `lib/dateUtils`
- update log and tts API endpoints to use `getCurrentDate`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68559eb8d834832cb2d211916cfba8f0